### PR TITLE
chore: Speed up build in CI

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -36,3 +36,5 @@ jobs:
           npm run lint:fix
           npm run format:fix
           npm run test:coverage
+        env:
+          CYPRESS_INSTALL_BINARY: 0

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -32,7 +32,7 @@ jobs:
       # app actions
       - name: app checks
         run: |
-          npm i
+          npm ci
           npm run lint:fix
           npm run format:fix
           npm run test:coverage


### PR DESCRIPTION
## Description
#### Jira Ticket: n/a

<!--- Describe your change. Why is this change required? What problem does it solve? Provide a jira ticket link if applied.-->

Speeds up the CI build:
- disable Cypress binary install via env variable
- use `npm ci` instead of plain install

Failing (currently) because of issues addressed in #37 but:

Before:
> added 3101 packages from 2085 contributors and audited 3446 packages in 72.842s

After:
> added 2673 packages in 37.856s
